### PR TITLE
Add ability to set overscan lines in image mode

### DIFF
--- a/archonApp/Db/archonCCD.template
+++ b/archonApp/Db/archonCCD.template
@@ -214,6 +214,30 @@ record(longin, "$(P)$(R)ArchonPreFrameSkip_RBV")
     field(SCAN, "I/O Intr")
 }
 
+# number of lines to overscan when acquiring the frame
+record(longout, "$(P)$(R)ArchonOverScan")
+{
+    field(PINI, "1")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARCHON_OVER_SCAN")
+    field(VAL,  "0")
+    info( autosaveFields, "VAL" )
+}
+
+record(longin, "$(P)$(R)ArchonOverScan_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARCHON_OVER_SCAN")
+    field(SCAN, "I/O Intr")
+}
+
+record(longin, "$(P)$(R)ArchonOverScanMax_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARCHON_OVER_SCAN_MAX")
+    field(SCAN, "I/O Intr")
+}
+
 record(ao, "$(P)$(R)ArchonNonIntTime")
 {
     field(PINI, "1")

--- a/archonApp/camera_config/STA4800.env
+++ b/archonApp/camera_config/STA4800.env
@@ -1,13 +1,14 @@
 #
 # ----- STA4800 ENV Vars -----
 #
-epicsEnvSet( "IMAGE_FTVL",			"SHORT"		)
-epicsEnvSet( "IMAGE_TYPE",			"Int16"		)
-epicsEnvSet( "IMAGE_BIT_DEPTH",		"16"		)
-epicsEnvSet( "IMAGE_XSIZE",			"4800"		)
-epicsEnvSet( "IMAGE_YSIZE",			"300"		)
-epicsEnvSet( "IMAGE_COLORMODE",		"0"			)	# 0=Mono,1=Bayer,2=RGB
-epicsEnvSet( "IMAGE_NELM",			"1440000"	)	# X*Y (B/W) or X*Y*3 (Color)
-epicsEnvSet( "RESOLUTION",			"15"		)
-epicsEnvSet( "RES_EGU",				"um"		)
+epicsEnvSet( "IMAGE_FTVL",          "SHORT"     )
+epicsEnvSet( "IMAGE_TYPE",          "Int16"     )
+epicsEnvSet( "IMAGE_BIT_DEPTH",     "16"        )
+epicsEnvSet( "IMAGE_XSIZE",         "4800"      )
+epicsEnvSet( "IMAGE_YSIZE",         "300"       )
+epicsEnvSet( "IMAGE_COLORMODE",     "0"         )   # 0=Mono,1=Bayer,2=RGB
+epicsEnvSet( "IMAGE_NELM",          "1440000"   )   # X*Y (B/W) or X*Y*3 (Color)
+epicsEnvSet( "RESOLUTION",          "15"        )
+epicsEnvSet( "RES_EGU",             "um"        )
+epicsEnvSet( "MAX_OVERSCAN",        "0"         )
 

--- a/archonApp/camera_config/STA4800_revE.env
+++ b/archonApp/camera_config/STA4800_revE.env
@@ -1,13 +1,14 @@
 #
 # ----- STA4800 ENV Vars -----
 #
-epicsEnvSet( "IMAGE_FTVL",			"SHORT"		)
-epicsEnvSet( "IMAGE_TYPE",			"Int16"		)
-epicsEnvSet( "IMAGE_BIT_DEPTH",		"16"		)
-epicsEnvSet( "IMAGE_XSIZE",			"4800"		)
-epicsEnvSet( "IMAGE_YSIZE",			"300"		)
-epicsEnvSet( "IMAGE_COLORMODE",		"0"			)	# 0=Mono,1=Bayer,2=RGB
-epicsEnvSet( "IMAGE_NELM",			"1440000"	)	# X*Y (B/W) or X*Y*3 (Color)
-epicsEnvSet( "RESOLUTION",			"15"		)
-epicsEnvSet( "RES_EGU",				"um"		)
+epicsEnvSet( "IMAGE_FTVL",          "SHORT"     )
+epicsEnvSet( "IMAGE_TYPE",          "Int16"     )
+epicsEnvSet( "IMAGE_BIT_DEPTH",     "16"        )
+epicsEnvSet( "IMAGE_XSIZE",         "4800"      )
+epicsEnvSet( "IMAGE_YSIZE",         "300"       )
+epicsEnvSet( "IMAGE_COLORMODE",     "0"         )   # 0=Mono,1=Bayer,2=RGB
+epicsEnvSet( "IMAGE_NELM",          "1440000"   )   # X*Y (B/W) or X*Y*3 (Color)
+epicsEnvSet( "RESOLUTION",          "15"        )
+epicsEnvSet( "RES_EGU",             "um"        )
+epicsEnvSet( "MAX_OVERSCAN",        "0"         )
 

--- a/archonApp/camera_config/STA5200.env
+++ b/archonApp/camera_config/STA5200.env
@@ -1,13 +1,14 @@
 #
 # ----- STA4800 ENV Vars -----
 #
-epicsEnvSet( "IMAGE_FTVL",			"SHORT"		)
-epicsEnvSet( "IMAGE_TYPE",			"Int16"		)
-epicsEnvSet( "IMAGE_BIT_DEPTH",		"16"		)
-epicsEnvSet( "IMAGE_XSIZE",			"4800"		)
-epicsEnvSet( "IMAGE_YSIZE",			"1024"		)
-epicsEnvSet( "IMAGE_COLORMODE",		"0"			)	# 0=Mono,1=Bayer,2=RGB
-epicsEnvSet( "IMAGE_NELM",			"4915200"	)	# X*Y (B/W) or X*Y*3 (Color)
-epicsEnvSet( "RESOLUTION",			"15"		)
-epicsEnvSet( "RES_EGU",				"um"		)
+epicsEnvSet( "IMAGE_FTVL",          "SHORT"     )
+epicsEnvSet( "IMAGE_TYPE",          "Int16"     )
+epicsEnvSet( "IMAGE_BIT_DEPTH",     "16"        )
+epicsEnvSet( "IMAGE_XSIZE",         "4800"      )
+epicsEnvSet( "IMAGE_YSIZE",         "1200"      )
+epicsEnvSet( "IMAGE_COLORMODE",     "0"         )   # 0=Mono,1=Bayer,2=RGB
+epicsEnvSet( "IMAGE_NELM",          "5760000"   )   # X*Y (B/W) or X*Y*3 (Color)
+epicsEnvSet( "RESOLUTION",          "15"        )
+epicsEnvSet( "RES_EGU",             "um"        )
+epicsEnvSet( "MAX_OVERSCAN",        "176"       )
 

--- a/archonApp/op/edl/ArchonCamType.edl
+++ b/archonApp/op/edl/ArchonCamType.edl
@@ -33,7 +33,7 @@ major 4
 minor 0
 release 0
 x 0
-y 244
+y 268
 w 176
 h 24
 
@@ -46,7 +46,7 @@ major 4
 minor 4
 release 0
 x 0
-y 244
+y 268
 w 176
 h 24
 fgColor index 14
@@ -82,7 +82,7 @@ major 4
 minor 7
 release 0
 x 22
-y 248
+y 272
 w 152
 h 16
 controlPv "$(P)$(R)CamModel"
@@ -172,7 +172,7 @@ major 4
 minor 7
 release 0
 x 144
-y 160
+y 184
 w 88
 h 20
 controlPv "$(P)$(R)ArchonClockAT"
@@ -197,7 +197,7 @@ major 4
 minor 7
 release 0
 x 248
-y 184
+y 208
 w 92
 h 20
 controlPv "$(P)$(R)ArchonClockST_RBV"
@@ -221,7 +221,7 @@ major 4
 minor 7
 release 0
 x 248
-y 208
+y 232
 w 92
 h 20
 controlPv "$(P)$(R)ArchonClockSTM1_RBV"
@@ -245,7 +245,7 @@ major 4
 minor 1
 release 1
 x 12
-y 184
+y 208
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -265,7 +265,7 @@ major 4
 minor 1
 release 1
 x 12
-y 208
+y 232
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -417,7 +417,7 @@ major 4
 minor 7
 release 0
 x 248
-y 160
+y 184
 w 92
 h 20
 controlPv "$(P)$(R)ArchonClockAT_RBV"
@@ -441,7 +441,7 @@ major 4
 minor 1
 release 1
 x 12
-y 160
+y 184
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -486,7 +486,7 @@ major 4
 minor 7
 release 0
 x 144
-y 184
+y 208
 w 88
 h 20
 controlPv "$(P)$(R)ArchonClockST"
@@ -511,7 +511,7 @@ major 4
 minor 7
 release 0
 x 144
-y 208
+y 232
 w 88
 h 20
 controlPv "$(P)$(R)ArchonClockSTM1"
@@ -671,5 +671,74 @@ useDisplayBg
 value {
   "POWER_PV: "
 }
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 12
+y 160
+w 120
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Overscan"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 144
+y 160
+w 88
+h 20
+controlPv "$(P)$(R)ArchonOverScan"
+format "decimal"
+font "helvetica-medium-r-12.0"
+fgColor index 25
+bgColor index 5
+editable
+motifWidget
+limitsFromDb
+nullColor index 40
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 248
+y 160
+w 92
+h 20
+controlPv "$(P)$(R)ArchonOverScan_RBV"
+format "decimal"
+font "helvetica-medium-r-14.0"
+fontAlign "center"
+fgColor index 15
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
 endObjectProperties
 

--- a/archonApp/op/edl/ArchonFeatures.edl
+++ b/archonApp/op/edl/ArchonFeatures.edl
@@ -6,7 +6,7 @@ release 1
 x 677
 y 54
 w 1070
-h 950
+h 975
 font "helvetica-medium-r-18.0"
 ctlFont "helvetica-bold-r-10.0"
 btnFont "helvetica-medium-r-18.0"
@@ -23,6 +23,21 @@ showGrid
 snapToGrid
 gridSize 4
 endScreenProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 380
+w 350
+h 578
+lineColor index 14
+fillColor index 14
+lineWidth 0
+endObjectProperties
 
 # (Rectangle)
 object activeRectangleClass
@@ -1943,7 +1958,7 @@ major 4
 minor 0
 release 0
 x 148
-y 858
+y 882
 w 80
 h 20
 fgColor index 14
@@ -1994,21 +2009,6 @@ h 20
 lineColor index 2
 fill
 fillColor index 2
-lineWidth 0
-endObjectProperties
-
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 380
-w 350
-h 554
-lineColor index 14
-fillColor index 14
 lineWidth 0
 endObjectProperties
 
@@ -2680,7 +2680,7 @@ major 4
 minor 1
 release 1
 x 17
-y 858
+y 882
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -2700,7 +2700,7 @@ major 4
 minor 1
 release 1
 x 17
-y 882
+y 906
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -2720,7 +2720,7 @@ major 4
 minor 1
 release 1
 x 17
-y 906
+y 930
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -2740,7 +2740,7 @@ major 4
 minor 7
 release 0
 x 240
-y 858
+y 882
 w 80
 h 20
 controlPv "$(P)$(R)DataType_RBV"
@@ -2946,7 +2946,7 @@ major 4
 minor 7
 release 0
 x 240
-y 762
+y 786
 w 80
 h 20
 controlPv "$(P)$(R)ArchonClockAT_RBV"
@@ -2970,7 +2970,7 @@ major 4
 minor 1
 release 1
 x 17
-y 762
+y 786
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -2990,7 +2990,7 @@ major 4
 minor 7
 release 0
 x 148
-y 762
+y 786
 w 80
 h 20
 controlPv "$(P)$(R)ArchonClockAT"
@@ -3015,7 +3015,7 @@ major 4
 minor 7
 release 0
 x 240
-y 786
+y 810
 w 80
 h 20
 controlPv "$(P)$(R)ArchonClockST_RBV"
@@ -3039,7 +3039,7 @@ major 4
 minor 1
 release 1
 x 17
-y 786
+y 810
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -3059,7 +3059,7 @@ major 4
 minor 7
 release 0
 x 148
-y 786
+y 810
 w 80
 h 20
 controlPv "$(P)$(R)ArchonClockST"
@@ -3084,7 +3084,7 @@ major 4
 minor 7
 release 0
 x 240
-y 810
+y 834
 w 80
 h 20
 controlPv "$(P)$(R)ArchonClockSTM1_RBV"
@@ -3108,7 +3108,7 @@ major 4
 minor 7
 release 0
 x 240
-y 882
+y 906
 w 80
 h 20
 controlPv "$(P)$(R)ArchonClearTime_RBV"
@@ -3133,7 +3133,7 @@ major 4
 minor 7
 release 0
 x 240
-y 906
+y 930
 w 80
 h 20
 controlPv "$(P)$(R)ArchonReadOutTime_RBV"
@@ -3158,7 +3158,7 @@ major 4
 minor 1
 release 1
 x 17
-y 810
+y 834
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -3178,7 +3178,7 @@ major 4
 minor 7
 release 0
 x 148
-y 810
+y 834
 w 80
 h 20
 controlPv "$(P)$(R)ArchonClockSTM1"
@@ -6371,7 +6371,7 @@ major 4
 minor 1
 release 1
 x 17
-y 834
+y 858
 w 120
 h 20
 font "helvetica-medium-r-14.0"
@@ -6391,7 +6391,7 @@ major 4
 minor 7
 release 0
 x 148
-y 834
+y 858
 w 80
 h 20
 controlPv "$(P)$(R)ArchonPocketPump"
@@ -6416,10 +6416,79 @@ major 4
 minor 7
 release 0
 x 240
-y 834
+y 858
 w 80
 h 20
 controlPv "$(P)$(R)ArchonPocketPump_RBV"
+format "decimal"
+font "helvetica-medium-r-14.0"
+fontAlign "center"
+fgColor index 15
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 17
+y 762
+w 120
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Overscan"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 148
+y 762
+w 80
+h 20
+controlPv "$(P)$(R)ArchonOverScan"
+format "decimal"
+font "helvetica-medium-r-14.0"
+fgColor index 25
+bgColor index 5
+editable
+motifWidget
+limitsFromDb
+nullColor index 40
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 240
+y 762
+w 80
+h 20
+controlPv "$(P)$(R)ArchonOverScan_RBV"
 format "decimal"
 font "helvetica-medium-r-14.0"
 fontAlign "center"

--- a/archonApp/op/edl/camModel.edl
+++ b/archonApp/op/edl/camModel.edl
@@ -6,7 +6,7 @@ release 1
 x 1924
 y 368
 w 1089
-h 985
+h 1025
 font "helvetica-medium-r-12.0"
 ctlFont "helvetica-medium-r-12.0"
 btnFont "helvetica-medium-r-12.0"
@@ -138,7 +138,7 @@ release 0
 x 8
 y 48
 w 1070
-h 950
+h 975
 fgColor index 14
 bgColor index 0
 topShadowColor index 1

--- a/archonApp/src/archonCCD.h
+++ b/archonApp/src/archonCCD.h
@@ -38,6 +38,8 @@
 #define ArchonPreFrameClearString     "ARCHON_PREFRAME_CLEAR"
 #define ArchonIdleClearString         "ARCHON_IDLE_CLEAR"
 #define ArchonPreFrameSkipString      "ARCHON_PREFRAME_SKIP"
+#define ArchonOverScanString          "ARCHON_OVER_SCAN"
+#define ArchonOverScanMaxString       "ARCHON_OVER_SCAN_MAX"
 #define ArchonNonIntTimeString        "ARCHON_NONINT_TIME"
 #define ArchonClockAtString           "ARCHON_CLOCK_AT"
 #define ArchonClockStString           "ARCHON_CLOCK_ST"
@@ -110,7 +112,7 @@ namespace Pds {
 class ArchonCCD : public ADDriver {
   public:
     ArchonCCD(const char *portName, const char *filePath, const char *cameraAddr, int cameraPort,
-              int maxBuffers, size_t maxMemory, int priority, int stackSize);
+              int maxBuffers, size_t maxMemory, int priority, int stackSize, int overScanMax);
     virtual ~ArchonCCD();
 
     /* These are the methods that we override from ADDriver */
@@ -185,6 +187,8 @@ class ArchonCCD : public ADDriver {
     int ArchonPreFrameClear;
     int ArchonIdleClear;
     int ArchonPreFrameSkip;
+    int ArchonOverScan;
+    int ArchonOverScanMax;
     int ArchonNonIntTime;
     int ArchonClockAt;
     int ArchonClockSt;


### PR DESCRIPTION
A new PV is added to add overscan lines to the image (ArchonOverScan). It sets the number of overscan lines to add to the image. The value is ignored in full vertical binning mode. Setting it to 176 reproduces the old hardcoded overscan behavior. Note normal vertical binning settings are applied to this value, so you don't need to change it when applying to the normal 2x vertical binning we often use.

Here is an example using it in ASC below:
<img width="626" alt="archon_overscan_example" src="https://github.com/user-attachments/assets/64675f81-88e7-43e9-8025-3423f97a7cc4" />

So in this overscan is set to 176 and the vertical binning is set to 2x which gives the end image with 600 rows.